### PR TITLE
Make cassandra consistency level configurable.

### DIFF
--- a/hdbpp.py
+++ b/hdbpp.py
@@ -112,7 +112,7 @@ class HDBPlusPlusConnection(object):
     "A very simple direct interface to the HDB++ cassandra backend"
 
     def __init__(self, nodes=None, keyspace="hdb", address_map=None,
-                 fetch_size=50000, cache_size=1e9):
+                 fetch_size=50000, cache_size=1e9, consistency_level="ONE"):
         self.nodes = nodes if nodes else ["localhost"]
         if address_map:
             translator = LocalNetworkAdressTranslator(address_map)
@@ -121,9 +121,7 @@ class HDBPlusPlusConnection(object):
             self.cluster = Cluster(self.nodes)
 
         s = self.cluster.connect(keyspace)
-        # TODO: Might be useful to be able to set the consistency
-        # level in the configuration
-        s.default_consistency_level = ConsistencyLevel.LOCAL_QUORUM
+        s.default_consistency_level = getattr(ConsistencyLevel, consistency_level)
         self.session = aiosession(s)  # asyncio wrapper
         self.session.default_fetch_size = fetch_size
 

--- a/hdbppviewer.conf
+++ b/hdbppviewer.conf
@@ -15,6 +15,10 @@ data_cache_size=1000000000
 nodes=b-kirk13-cas-3,b-kirk13-cas-4,b-kirk13-cas-5,b-picard13-cas-0,b-picard13-cas-1,b-picard13-cas-2
 # name of the keyspace to use
 keyspace=hdb
+# Consistency level for reading data. Must be one of the levels listed on
+# https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html
+# Defaults to ONE
+consistency_level=ONE
 
 # [hdbpp:cassandra_address_translation]
 # # This is a driver feature which allows a mapping between cassandra

--- a/server.py
+++ b/server.py
@@ -235,8 +235,9 @@ if __name__ == "__main__":
     config = configparser.RawConfigParser()
     config.read(args.config)
     PORT = config.getint("server", "port")
-    CASSANDRA_NODES = config.get("hdbpp:cassandra", "nodes").split(",")
-    CASSANDRA_KEYSPACE = config.get("hdbpp:cassandra", "keyspace")
+    CASSANDRA_NODES = config["hdbpp:cassandra"].get("nodes").split(",")
+    CASSANDRA_KEYSPACE = config["hdbpp:cassandra"].get("keyspace")
+    CASSANDRA_CONSISTENCY_LEVEL = config["hdbpp:cassandra"].get("consistency_level", "ONE")
     if config.has_section("hdbpp:cassandra_address_translation"):
         CASSANDRA_ADDRESS_TRANSLATION = dict(
             config.items("hdbpp:cassandra_address_translation"))
@@ -253,7 +254,8 @@ if __name__ == "__main__":
     hdbpp = HDBPlusPlusConnection(nodes=CASSANDRA_NODES,
                                   keyspace=CASSANDRA_KEYSPACE,
                                   address_map=CASSANDRA_ADDRESS_TRANSLATION,
-                                  cache_size=DATA_CACHE_SIZE)
+                                  cache_size=DATA_CACHE_SIZE,
+                                  consistency_level=CASSANDRA_CONSISTENCY_LEVEL)
 
     app.router.add_route('GET', '/controlsystems',
                          partial(get_controlsystems, hdbpp))


### PR DESCRIPTION
The consistency level determines how "strict" the cassandra driver is about the data consistency when reading. 

By default, now it's content to ask any single node, which means that we won't always get the very latest data. I think this is OK in most cases, but we will see if it causes problems. The setting is now configurable and therefore easy to tweak.

The old setting of LOCAL_QUORUM causes problems because of how our Cassandra and HDB++ systems are set up. If even a single node in the cluster is down, the viewer would have problems.